### PR TITLE
Text can be highlighted without a className

### DIFF
--- a/jquery.highlight.js
+++ b/jquery.highlight.js
@@ -30,6 +30,10 @@
  *   // with <em class='important'>
  *   $('#content').highlight('ipsum', { element: 'em', className: 'important' });
  *
+ *   // wrap every occurrance of term 'ipsum' in content
+ *   // with <em>
+ *   $('#content').highlight('ipsum', { element: 'em', className: false });
+ *
  *   // remove default highlight
  *   $('#content').unhighlight();
  *
@@ -49,7 +53,9 @@ jQuery.extend({
             var match = node.data.match(re);
             if (match) {
                 var highlight = document.createElement(nodeName || 'span');
-                highlight.className = className || 'highlight';
+                if (className) {
+                  highlight.className = className;
+                }
                 var wordNode = node.splitText(match.index);
                 wordNode.splitText(match[0].length);
                 var wordClone = wordNode.cloneNode(true);


### PR DESCRIPTION
Hello,

Thanks for the plugin; we really appreciate your hard work.

In our use case, we don't need the highlighted text's parent tag to have a className. Here is the API we introduced:

```
// wrap every occurrance of term 'ipsum' in content
// with <em>
$('#content').highlight('ipsum', { element: 'em', className: false });
```

Also, I refactored the highlight function to not set a default className. It seemed redundant since the settings variable handles all defaults.

Hope you find this code useful and thanks again,
Simeon
