### PR TITLE
Use jQuery/resources over HTTPS for GitHub pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,12 @@
 
 <body>
 
-<a href="http://github.com/bartaz/sandbox.js"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+<a href="https://github.com/bartaz/sandbox.js"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
 
 <div id="container">
 	<h1>
-		<a href="http://github.com/bartaz/sandbox.js">sandbox.js</a> 
-		<span class="small">by <a href="http://github.com/bartaz">bartaz</a></span>
+		<a href="https://github.com/bartaz/sandbox.js">sandbox.js</a> 
+		<span class="small">by <a href="https://github.com/bartaz">bartaz</a></span>
 	</h1>
 
 	<div class="description">My little place to play with JavaScript</div>
@@ -43,7 +43,7 @@
 	
 	<div id="copyright">
 		<p>Copyright &copy; 2009 Bartek Szopka</p>
-		<p>get the source code on GitHub : <a href="http://github.com/bartaz/sandbox.js">bartaz/sandbox.js</a></p>
+		<p>get the source code on GitHub : <a href="https://github.com/bartaz/sandbox.js">bartaz/sandbox.js</a></p>
 	</div>
 
 </div>

--- a/jquery.highlight.html
+++ b/jquery.highlight.html
@@ -6,7 +6,7 @@
 
 	<link rel="stylesheet" href="style.css" type="text/css"  />
 	
-	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js">
+	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js">
 	</script>
 	<script type="text/javascript" src="jquery.highlight.js">
 	</script>

--- a/string_object_test.html
+++ b/string_object_test.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 	<title>jQuery.fn.html(new String("test case")</title>
-	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.js"></script>
+	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.js"></script>
 	<script type="text/javascript">
 		//<![CDATA[
 		


### PR DESCRIPTION
These are prevented from loading due to security errors now that GitHub pages is HTTPS-only (eg `https://bartaz.github.io/sandbox.js/jquery.highlight.html`)

Also adjust a few http:// links to GitHub in the process.
